### PR TITLE
Fix errors when a satellite node is offline

### DIFF
--- a/cinder/volume/drivers/linstordrv.py
+++ b/cinder/volume/drivers/linstordrv.py
@@ -948,18 +948,14 @@ class LinstorBaseDriver(driver.VolumeDriver):
             # Create resources and,
             # Check only errors when creating diskless resources
             if 'Diskless' in node['driver_name']:
-                noerror_only = True
-                rsc_reply = self._api_rsc_create(rsc_name=rsc_name,
-                                                 node_name=node['node_name'],
-                                                 diskless=True)
-
+                diskless = True
             else:
-                noerror_only = False
-                rsc_reply = self._api_rsc_create(rsc_name=rsc_name,
-                                                 node_name=node['node_name'],
-                                                 diskless=False)
+                diskless = False
+            rsc_reply = self._api_rsc_create(rsc_name=rsc_name,
+                                             node_name=node['node_name'],
+                                             diskless=diskless)
 
-            if not self._debug_api_reply(rsc_reply, noerror_only=noerror_only):
+            if not self._debug_api_reply(rsc_reply, noerror_only=True):
                 msg = _("Error creating a LINSTOR resource")
                 LOG.error(msg)
                 raise exception.VolumeBackendAPIException(data=msg)
@@ -1004,7 +1000,7 @@ class LinstorBaseDriver(driver.VolumeDriver):
                     rsc_reply = self._api_rsc_delete(
                         node_name=node['nodeName'],
                         rsc_name=drbd_rsc_name)
-                    if not self._debug_api_reply(rsc_reply):
+                    if not self._debug_api_reply(rsc_reply, noerror_only=True):
                         msg = _("Error deleting a LINSTOR resource")
                         LOG.error(msg)
                         raise exception.VolumeBackendAPIException(data=msg)
@@ -1044,7 +1040,7 @@ class LinstorBaseDriver(driver.VolumeDriver):
 
         snap_reply = self._get_api_volume_extend(rsc_target_name, new_size)
 
-        if not self._debug_api_reply(snap_reply):
+        if not self._debug_api_reply(snap_reply, noerror_only=True):
             msg = _("ERROR Linstor Volume Extend")
             LOG.error(msg)
             raise exception.VolumeBackendAPIException(data=msg)
@@ -1310,7 +1306,7 @@ class LinstorDrbdDriver(LinstorBaseDriver):
             rsc_reply = self._api_rsc_create(rsc_name=full_rsc_name,
                                              node_name=node_name,
                                              diskless=True)
-            if not self._debug_api_reply(rsc_reply):
+            if not self._debug_api_reply(rsc_reply, noerror_only=True):
                 msg = _('Error on creating LINSTOR Resource')
                 LOG.error(msg)
                 raise exception.VolumeBackendAPIException(data=msg)
@@ -1335,7 +1331,7 @@ class LinstorDrbdDriver(LinstorBaseDriver):
             full_rsc_name = self._drbd_resource_name_from_cinder_volume(volume)
             rsc_reply = self._api_rsc_delete(rsc_name=full_rsc_name,
                                              node_name=node_name)
-            if not self._debug_api_reply(rsc_reply):
+            if not self._debug_api_reply(rsc_reply, noerror_only=True):
                 msg = _('Error on deleting LINSTOR Resource')
                 LOG.error(msg)
                 raise exception.VolumeBackendAPIException(data=msg)

--- a/cinder/volume/drivers/linstordrv.py
+++ b/cinder/volume/drivers/linstordrv.py
@@ -491,14 +491,15 @@ class LinstorBaseDriver(driver.VolumeDriver):
                         sp_node['sp_cap'] = 0.0
                     else:
                         diskless = False
-                        sp_node['sp_free'] = round(
-                            int(node['freeSpace']['freeCapacity']) / 1048576,
-                            2)
-                        sp_node['sp_cap'] = round(
-                            int(node['freeSpace']['totalCapacity']) / 1048576,
-                            2)
+                        if 'freeSpace' in node:
+                            sp_node['sp_free'] = round(
+                                int(node['freeSpace']['freeCapacity']) / 1048576,
+                                2)
+                            sp_node['sp_cap'] = round(
+                                int(node['freeSpace']['totalCapacity']) / 1048576,
+                                2)
 
-                    # Driver
+                            # Driver
                     if node['driver'] == "LvmDriver":
                         sp_node['driver_name'] = LVM
                     elif node['driver'] == "LvmThinDriver":


### PR DESCRIPTION
When one satellite of a storage pool is offline, we have errors:
- when creating and deleting volume
- when initializing and terminating connections
- when extending volume
- when calculating disk space

And new resources are not properly deployed on all nodes because the offline nodes no longer appear in the resource_list.resourceState object.

In this PR, there will be all the corrections to these problems.